### PR TITLE
Bugfix/fix broken links in documentation

### DIFF
--- a/simplified_api/README.md
+++ b/simplified_api/README.md
@@ -20,7 +20,7 @@ This software has been tested on **Ubuntu 16.04 (64-bit)** and **Windows 10**
 ## Download instructions
 
 ## Installation Instructions
-You can access the latest release of the MATLAB adaptor [here](https://artifactory.kinovaapps.com/artifactory/webapp/#/artifacts/browse/tree/General/generic-local-public/kortex/matlab/simplified_api/) on the Kinova Artifactory.
+You can access the latest release of the MATLAB adaptor [here](https://artifactory.kinovaapps.com/artifactory/webapp/#/artifacts/browse/tree/General/generic-public/kortex/matlab/simplified_API/) on the Kinova Artifactory.
 
 ### Windows Operating System
 From the Kinova Artifactory:

--- a/simplified_api/documentation/precomputed_joint_trajectories.md
+++ b/simplified_api/documentation/precomputed_joint_trajectories.md
@@ -7,7 +7,7 @@ The Precomputed Joint Trajectories is the way to send the arm through joint-spac
 
 ### kObjTrajectoryFeeder object
 
-The kObjTrajectoryFeeder object in the [example Simulink model](../mex-wrapper/example_model.slx) reads a Precomputed Joint Trajectory (computed offline with a motion planner) from a [CSV file](../mex-wrapper/testpoints.csv) and sends it to the kortex System Object. You will most likely create your own object to send your trajectories to the kortex System object.
+The kObjTrajectoryFeeder object in the example Simulink model reads a Precomputed Joint Trajectory (computed offline with a motion planner) from a CSV file. and sends it to the kortex System Object. You will most likely create your own object to send your trajectories to the kortex System object. Both the Simulink model and the CSV file used in the exampel can be found in the [latest release of the MATLAB adaptor](https://artifactory.kinovaapps.com/artifactory/webapp/#/artifacts/browse/tree/General/generic-local-public/kortex/matlab/simplified_api/).
 
 ### Structure of the input arrays
 

--- a/simplified_api/documentation/precomputed_joint_trajectories.md
+++ b/simplified_api/documentation/precomputed_joint_trajectories.md
@@ -7,7 +7,7 @@ The Precomputed Joint Trajectories is the way to send the arm through joint-spac
 
 ### kObjTrajectoryFeeder object
 
-The kObjTrajectoryFeeder object in the example Simulink model reads a Precomputed Joint Trajectory (computed offline with a motion planner) from a CSV file. and sends it to the kortex System Object. You will most likely create your own object to send your trajectories to the kortex System object. Both the Simulink model and the CSV file used in the exampel can be found in the [latest release of the MATLAB adaptor](https://artifactory.kinovaapps.com/artifactory/webapp/#/artifacts/browse/tree/General/generic-local-public/kortex/matlab/simplified_api/).
+The kObjTrajectoryFeeder object in the example Simulink model reads a Precomputed Joint Trajectory (computed offline with a motion planner) from a CSV file. and sends it to the kortex System Object. You will most likely create your own object to send your trajectories to the kortex System object. Both the Simulink model and the CSV file used in the exampel can be found in the [latest release of the MATLAB adaptor](https://artifactory.kinovaapps.com/artifactory/webapp/#/artifacts/browse/tree/General/generic-public/kortex/matlab/simplified_API/).
 
 ### Structure of the input arrays
 

--- a/simplified_api/documentation/system_object.md
+++ b/simplified_api/documentation/system_object.md
@@ -193,7 +193,7 @@ No input
 |   Name   |  Type  | Description                                                                                               |
 |:--------:|:-------|-----------------------------------------------------------------------------------------------------------|
 | isOk     | bool   | A flag that indicates if the function has been executed correctly.                                        |
-| status   | uint32 | Current movement status. Based on C enum MovementStatus from [kortex_wrapper_data.h](../mex-wrapper/include/kortex_wrapper_data.h). |
+| status   | uint32 | Current movement status. Based on C enum MovementStatus from kortex_wrapper_data.h. |
 
 #### GetOptionValue
 This function returns the value of an option on a specific sensor.
@@ -201,8 +201,8 @@ This function returns the value of an option on a specific sensor.
 ##### Function Inputs
 |   Name    |  Type   | Description                                                                                               |
 |:---------:|:-------:|-----------------------------------------------------------------------------------------------------------|
-|  sensor   | uint32  | Target sensor. Based on C enum **Sensor** from [kortex_wrapper_data.h](../mex-wrapper/include/kortex_wrapper_data.h). |
-|  option   | uint32  | Target option. Based on C enum **Option** from [kortex_wrapper_data.h](../mex-wrapper/include/kortex_wrapper_data.h). |
+|  sensor   | uint32  | Target sensor. Based on C enum **Sensor** from kortex_wrapper_data.h. |
+|  option   | uint32  | Target option. Based on C enum **Option** from kortex_wrapper_data.h. |
 
 ##### Function Outputs
 |   Name    |  Type              | Description                                                                                               |
@@ -216,15 +216,15 @@ This function returns the configured settings of a specific sensor.
 ##### Function Inputs
 |   Name    |  Type   | Description                                                                                               |
 |:---------:|:-------:|-----------------------------------------------------------------------------------------------------------|
-|  sensor   | uint32  | Target sensor. Based on C enum **Sensor** from [kortex_wrapper_data.h](../mex-wrapper/include/kortex_wrapper_data.h). |
+|  sensor   | uint32  | Target sensor. Based on C enum **Sensor** from kortex_wrapper_data.h. |
 
 ##### Function Outputs
 |   Name     |  Type  | Description                                                                                               |
 |:----------:|:------:|-----------------------------------------------------------------------------------------------------------|
 | isOk       | bool   | A flag that indicates if the function has been executed correctly.                                        |
-| resolution | uint32 | Resolution of the targeted sensor. Based on the C enum **Sensor** from [kortex_wrapper_data.h](../mex-wrapper/include/kortex_wrapper_data.h). |
-| frame_rate | uint32 | Frame rate of the targeted sensor. Resolution of the targeted sensor. Based on C enum **Sensor** from [kortex_wrapper_data.h](../mex-wrapper/include/kortex_wrapper_data.h). |
-| bit_rate   | uint32 | Bit rate of the targeted sensor. Resolution of the targeted sensor. Based on C enum **Sensor** from [kortex_wrapper_data.h](../mex-wrapper/include/kortex_wrapper_data.h). |
+| resolution | uint32 | Resolution of the targeted sensor. Based on the C enum **Sensor** from kortex_wrapper_data.h. |
+| frame_rate | uint32 | Frame rate of the targeted sensor. Resolution of the targeted sensor. Based on C enum **Sensor** from kortex_wrapper_data.h. |
+| bit_rate   | uint32 | Bit rate of the targeted sensor. Resolution of the targeted sensor. Based on C enum **Sensor** from kortex_wrapper_data.h. |
 
 #### GetSensorSettings
 This function returns the configured settings of a specific sensor.
@@ -232,16 +232,16 @@ This function returns the configured settings of a specific sensor.
 ##### Function Inputs
 |   Name    |  Type   | Description                                                                                               |
 |:---------:|:-------:|-----------------------------------------------------------------------------------------------------------|
-|  sensor   | uint32  | Target sensor. Based on C enum **Sensor** from [kortex_wrapper_data.h](../mex-wrapper/include/kortex_wrapper_data.h). |
+|  sensor   | uint32  | Target sensor. Based on C enum **Sensor** from kortex_wrapper_data.h. |
 
 ##### Function Outputs
 |   Name     |  Type  | Description                                                                                               |
 |:----------:|:------:|-----------------------------------------------------------------------------------------------------------|
 | isOk       | bool   | A flag that indicates if the function has been executed correctly.                                        |
                                                     |
-| resolution | uint32 | Resolution of the targeted sensor. Based on the C enum **Sensor** from [kortex_wrapper_data.h](../mex-wrapper/include/kortex_wrapper_data.h). |
-| frame_rate | uint32 | Frame rate of the targeted sensor. Resolution of the targeted sensor. Based on C enum **Sensor** from [kortex_wrapper_data.h](../mex-wrapper/include/kortex_wrapper_data.h). |
-| bit_rate   | uint32 | Bit rate of the targeted sensor. Resolution of the targeted sensor. Based on C enum **Sensor** from [kortex_wrapper_data.h](../mex-wrapper/include/kortex_wrapper_data.h). |
+| resolution | uint32 | Resolution of the targeted sensor. Based on the C enum **Sensor** from kortex_wrapper_data.h. |
+| frame_rate | uint32 | Frame rate of the targeted sensor. Resolution of the targeted sensor. Based on C enum **Sensor** from kortex_wrapper_data.h. |
+| bit_rate   | uint32 | Bit rate of the targeted sensor. Resolution of the targeted sensor. Based on C enum **Sensor** from kortex_wrapper_data.h. |
 
 #### DoSensorFocusAction
 Execute a focus action on the camera. You can find a C++ example [here](https://github.com/Kinovarobotics/kortex/blob/master/api_cpp/examples/500-Vision/03_vision_sensor_focus_action.cpp) that explains how to use this function.
@@ -249,8 +249,8 @@ Execute a focus action on the camera. You can find a C++ example [here](https://
 ##### Function Inputs
 |   Name        |  Type   | Description                                                                                               |
 |:-------------:|:-------:|-----------------------------------------------------------------------------------------------------------|
-|  sensor       | uint32  | Target sensor. Based on C enum **Sensor** from [kortex_wrapper_data.h](../mex-wrapper/include/kortex_wrapper_data.h). |
-|  focus_action | uint32  | Target sensor. Based on C enum **FocusAction** from [kortex_wrapper_data.h](../mex-wrapper/include/kortex_wrapper_data.h). |
+|  sensor       | uint32  | Target sensor. Based on C enum **Sensor** from kortex_wrapper_data.h. |
+|  focus_action | uint32  | Target sensor. Based on C enum **FocusAction** from kortex_wrapper_data.h. |
 
 ##### Function Outputs
 |   Name     |  Type  | Description                                                                                               |

--- a/vision_imaq/README.md
+++ b/vision_imaq/README.md
@@ -32,7 +32,7 @@ sudo apt install libglib2.0-0
 ```
 
 ## Installation Instructions
-You can access the latest release of the Vision Module MATLAB Image Acquisition Toolbox Adaptor [here](https://artifactory.kinovaapps.com/artifactory/generic-local-public/kortex/matlab/vision/1.0.0/matlab_vision_imaq_1.0.0.zip) on the Kinova Artifactory.
+You can access the latest release of the Vision Module MATLAB Image Acquisition Toolbox Adaptor [here](https://artifactory.kinovaapps.com/artifactory/generic-public/kortex/matlab/vision/1.0.0/matlab_vision_imaq_1.0.0.zip) on the Kinova Artifactory.
 
 Uncompress the archive to access either the Windows or Linux binaries:
 


### PR DESCRIPTION
This PR fixes the broken links in the documentation due to missing folders and files.

 Please note that the missing folders and files can be found in the latest release of the [MATLAB adapter](https://artifactory.kinovaapps.com/artifactory/webapp/#/artifacts/browse/tree/General/generic-public/kortex/matlab/simplified_API/).

The documentation inside the MATLAB adpater will remain unchanged since the links will work properly inside it.